### PR TITLE
Improve robustness for playlist track metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,15 +125,26 @@ def create_track_dataframe(tracks):
     """Create a simple dataframe of track info"""
     data = []
     for item in tracks:
-        track = item['track']
-        if track:
-            data.append({
-                'Track Name': track['name'],
-                'Artist': track['artists'][0]['name'],
-                'Album': track['album']['name'],
-                'Popularity': track.get('popularity', 0)
-            })
-    
+        track = item.get('track')
+        if not track:
+            continue
+
+        # Some playlist entries (like local files) may not include complete
+        # metadata. Safely extract values and fall back to sensible defaults
+        # to avoid KeyError/IndexError crashes during analysis.
+        artists = track.get('artists') or []
+        artist_name = artists[0]['name'] if artists else 'Unknown Artist'
+
+        album = track.get('album') or {}
+        album_name = album.get('name', 'Unknown Album')
+
+        data.append({
+            'Track Name': track.get('name', 'Unknown Track'),
+            'Artist': artist_name,
+            'Album': album_name,
+            'Popularity': track.get('popularity', 0)
+        })
+
     return pd.DataFrame(data)
 
 def main():


### PR DESCRIPTION
## Summary
- Avoid crashes when playlist entries lack artist or album info by safely handling missing metadata

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'\nimport types, sys\nclass Dummy:\n    def __getattr__(self, name):\n        def func(*args, **kwargs):\n            return None\n        return func\nsys.modules['streamlit'] = Dummy()\nfrom app import create_track_dataframe\ntracks = [{'track': None},{'track': {'name': 'Song 1','artists': [{'name': 'Artist1'}],'album': {'name': 'Album1'},'popularity': 50}},{'track': {'name': 'Song 2','artists': [],'album': {},'popularity': 70}}]\nprint(create_track_dataframe(tracks))\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68959eefcf08832ab144abce826ccc01